### PR TITLE
Xamarin.ExposureNotifications.LogEx の追加

### DIFF
--- a/Covid19Radar/Covid19Radar.Android/MainActivity.cs
+++ b/Covid19Radar/Covid19Radar.Android/MainActivity.cs
@@ -53,19 +53,19 @@ namespace Covid19Radar.Droid
             }
             */
 
-            /*
             // ログ用のパスを一度取得する
             // こうしないと files フォルダが作られない
             var contextRef = new System.WeakReference<Context>(this);
             contextRef.TryGetTarget(out var c);
             var dir = c.GetExternalFilesDir(null).AbsolutePath;
-            var filename = Path.Combine(dir, $"trace-droid-{DateTime.Now.ToString("yyyyMMdd-HHmm")}.txt");
-            var tw = System.IO.File.OpenWrite(filename);
-            var tr1 = new System.Diagnostics.TextWriterTraceListener(tw);
-            DroidTrace.AutoFlush = true;
-            DroidTrace.Listeners.Add(tr1);
-            DroidTrace.WriteLine("START: " + DateTime.Now.ToString());
-            */
+            var filename = Path.Combine(dir, $"trace-dummy.txt");
+            using (var tw = System.IO.File.OpenWrite(filename))
+            {
+                using (var sw = new StreamWriter(tw))
+                {
+                    sw.WriteLine("START: " + DateTime.Now.ToString());
+                }
+            }
 
 
             //NotificationCenter.CreateNotificationChannel();

--- a/Covid19Radar/Covid19Radar.Android/Properties/AndroidManifest.xml
+++ b/Covid19Radar/Covid19Radar.Android/Properties/AndroidManifest.xml
@@ -1,5 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
-<manifest xmlns:android="http://schemas.android.com/apk/res/android" android:versionCode="5" android:versionName="APP_VERSION" package="net.moonmile.sample.opencacao.backtask" android:installLocation="auto">
+<manifest xmlns:android="http://schemas.android.com/apk/res/android" android:versionCode="5" android:versionName="1.2.2" package="net.moonmile.sample.opencacao.backtask" android:installLocation="auto">
 	<uses-sdk android:minSdkVersion="23" android:targetSdkVersion="29" />
 	<application android:label="@string/app_name" android:icon="@mipmap/ic_launcher" android:fullBackupContent="@xml/backup_settings"></application>
 	<uses-feature android:name="android.hardware.bluetooth_le" android:required="true" />

--- a/Covid19Radar/Covid19Radar.Android/Properties/AndroidManifest.xml
+++ b/Covid19Radar/Covid19Radar.Android/Properties/AndroidManifest.xml
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <manifest xmlns:android="http://schemas.android.com/apk/res/android" android:versionCode="5" android:versionName="1.2.2" package="net.moonmile.sample.opencacao.backtask" android:installLocation="auto">
 	<uses-sdk android:minSdkVersion="23" android:targetSdkVersion="29" />
-	<application android:label="@string/app_name" android:icon="@mipmap/ic_launcher" android:fullBackupContent="@xml/backup_settings"></application>
+	<application android:label="CACAO BACKTASK" android:icon="@mipmap/ic_launcher" android:fullBackupContent="@xml/backup_settings"></application>
 	<uses-feature android:name="android.hardware.bluetooth_le" android:required="true" />
 	<uses-feature android:name="android.hardware.bluetooth" />
 	<uses-permission android:name="android.permission.BLUETOOTH" />

--- a/Covid19Radar/Covid19Radar/App.xaml.cs
+++ b/Covid19Radar/Covid19Radar/App.xaml.cs
@@ -57,8 +57,8 @@ namespace Covid19Radar
             Xamarin.ExposureNotifications.ExposureNotification.Init();
             Xamarin.ExposureNotifications.LoggerService.Instance = LoggerService;
 
-            var enabled = await Xamarin.ExposureNotifications.ExposureNotification.IsEnabledAsync();
-            App.LoggerService.Info($"IsEnabledAsync is {enabled}");
+            // var enabled = await Xamarin.ExposureNotifications.ExposureNotification.IsEnabledAsync();
+            // App.LoggerService.Info($"IsEnabledAsync is {enabled}");
 
             // Local Notification tap event listener
             //NotificationCenter.Current.NotificationTapped += OnNotificationTapped;

--- a/Covid19Radar/Covid19Radar/App.xaml.cs
+++ b/Covid19Radar/Covid19Radar/App.xaml.cs
@@ -55,7 +55,6 @@ namespace Covid19Radar
             Xamarin.ExposureNotifications.ExposureNotification.OverrideNativeImplementation(new Services.TestNativeImplementation());
 #endif
             Xamarin.ExposureNotifications.ExposureNotification.Init();
-            Xamarin.ExposureNotifications.LoggerService.Instance = LoggerService;
 
             // var enabled = await Xamarin.ExposureNotifications.ExposureNotification.IsEnabledAsync();
             // App.LoggerService.Info($"IsEnabledAsync is {enabled}");

--- a/Covid19Radar/Covid19Radar/Services/Logs/ILoggerService.cs
+++ b/Covid19Radar/Covid19Radar/Services/Logs/ILoggerService.cs
@@ -3,11 +3,6 @@ using System.Runtime.CompilerServices;
 
 namespace Covid19Radar.Services.Logs
 {
-#if TEST_BACKTASK
-    // インターフェースを切り替えてしまう
-    // これは ILoggerService を別アセンブリにしたほうが良い
-    public interface ILoggerService : Xamarin.ExposureNotifications.ILoggerServiceInner { }
-#else
     public interface ILoggerService
     {
         void StartMethod(
@@ -50,6 +45,4 @@ namespace Covid19Radar.Services.Logs
             [CallerFilePath] string filePath = "",
             [CallerLineNumber] int lineNumber = 0);
     }
-#endif
-
 }

--- a/Covid19Radar/Xamarin.ExposureNotification/ExposureNotification.android.cs
+++ b/Covid19Radar/Xamarin.ExposureNotification/ExposureNotification.android.cs
@@ -31,10 +31,9 @@ namespace Xamarin.ExposureNotifications
 
 		static async Task<ExposureConfiguration> GetConfigurationAsync()
 		{
-			// ログを入れる
-			LoggerService.StartMethod();
-
+			LogEx.StartMethod();
 			var c = await Handler.GetConfigurationAsync();
+			LogEx.EndMethod();
 
 
 			return new ExposureConfiguration.ExposureConfigurationBuilder()
@@ -69,8 +68,7 @@ namespace Xamarin.ExposureNotifications
 
 		static async Task<T> ResolveApi<T>(int requestCode, Func<Task<T>> apiCall)
 		{
-			// ログを入れる
-			LoggerService.StartMethod();
+			LogEx.StartMethod();
 			try
 			{
 				return await apiCall();
@@ -97,16 +95,14 @@ namespace Xamarin.ExposureNotifications
 
 		static void PlatformInit()
 		{
-			// ログを入れる
-			LoggerService.StartMethod(); // Init 前なのでこれ書き出せない
+			LogEx.StartMethod();
 			_ = ScheduleFetchAsync();
 		}
 
 		static Task PlatformStart()
 			=> ResolveApi<object>(requestCodeStartExposureNotification, async () =>
 				{
-					// ログを入れる
-					LoggerService.StartMethod();
+					LogEx.StartMethod();
 					await Instance.StartAsync();
 					return default;
 				});
@@ -114,8 +110,7 @@ namespace Xamarin.ExposureNotifications
 		static Task PlatformStop()
 			=> ResolveApi<object>(requestCodeStartExposureNotification, async () =>
 				{
-					// ログを入れる
-					LoggerService.StartMethod();
+					LogEx.StartMethod();
 					await Instance.StopAsync();
 					return default;
 				});
@@ -215,10 +210,8 @@ namespace Xamarin.ExposureNotifications
 
 		static async Task<Status> PlatformGetStatusAsync()
 		{
-			// ログを入れる
-			LoggerService.StartMethod();
+			LogEx.StartMethod();
 			var bt = BluetoothAdapter.DefaultAdapter;
-
 			if (bt == null || !bt.IsEnabled)
 				return Status.BluetoothOff;
 

--- a/Covid19Radar/Xamarin.ExposureNotification/ExposureNotification.android.cs
+++ b/Covid19Radar/Xamarin.ExposureNotification/ExposureNotification.android.cs
@@ -24,10 +24,10 @@ namespace Xamarin.ExposureNotifications
 {
 	public static partial class ExposureNotification
 	{
-		static IExposureNotificationClient instance;
-
-		static IExposureNotificationClient Instance
-			=> instance ??= Nearby.GetExposureNotificationClient(Application.Context);
+		static Xamarin.ExposureNotification.ExposureNotificationClientMock Instance => new Xamarin.ExposureNotification.ExposureNotificationClientMock();
+		// static IExposureNotificationClient instance;
+		//		static IExposureNotificationClient Instance
+		//			=> instance ??= Nearby.GetExposureNotificationClient(Application.Context);
 
 		static async Task<ExposureConfiguration> GetConfigurationAsync()
 		{

--- a/Covid19Radar/Xamarin.ExposureNotification/LoggerService.shared.cs
+++ b/Covid19Radar/Xamarin.ExposureNotification/LoggerService.shared.cs
@@ -6,106 +6,128 @@ using System.Text;
 namespace Xamarin.ExposureNotifications
 {
     /// <summary>
-    /// Xamarin.ExposureNotification 内で利用する LoggerService
+    /// System.Diagnostics.Trace の拡張メソッド
     /// </summary>
-    public class LoggerService
+    public static class LogEx
     {
-        private static ILoggerServiceInner _target;
-        public static ILoggerServiceInner Instance
+        private enum LogLevel
         {
-            get => _target;
-            set => _target = value;
+            Verbose,
+            Debug,
+            Info,
+            Warning,
+            Error
         }
+
         public static void StartMethod(
             [CallerMemberName] string method = "",
             [CallerFilePath] string filePath = "",
             [CallerLineNumber] int lineNumber = 0)
-        { _target?.StartMethod(method, filePath, lineNumber); }
+        {
+            Output("Start", method, filePath, lineNumber, LogLevel.Info);
+        }
 
         public static void EndMethod(
             [CallerMemberName] string method = "",
             [CallerFilePath] string filePath = "",
             [CallerLineNumber] int lineNumber = 0)
-        { _target?.StartMethod(method, filePath, lineNumber); }
+        {
+            Output("End", method, filePath, lineNumber, LogLevel.Info);
+        }
+
         public static void Verbose(
             string message,
             [CallerMemberName] string method = "",
             [CallerFilePath] string filePath = "",
             [CallerLineNumber] int lineNumber = 0)
-        { _target?.StartMethod(method, filePath, lineNumber); }
+        {
+            Output(message, method, filePath, lineNumber, LogLevel.Verbose);
+        }
+
         public static void Debug(
             string message,
             [CallerMemberName] string method = "",
             [CallerFilePath] string filePath = "",
             [CallerLineNumber] int lineNumber = 0)
-        { _target?.StartMethod(method, filePath, lineNumber); }
+        {
+            Output(message, method, filePath, lineNumber, LogLevel.Debug);
+        }
+
         public static void Info(
             string message,
             [CallerMemberName] string method = "",
             [CallerFilePath] string filePath = "",
             [CallerLineNumber] int lineNumber = 0)
-        { _target?.StartMethod(method, filePath, lineNumber); }
+        {
+            Output(message, method, filePath, lineNumber, LogLevel.Info);
+        }
+
         public static void Warning(
             string message,
             [CallerMemberName] string method = "",
             [CallerFilePath] string filePath = "",
             [CallerLineNumber] int lineNumber = 0)
-        { _target?.StartMethod(method, filePath, lineNumber); }
+        {
+            Output(message, method, filePath, lineNumber, LogLevel.Warning);
+        }
+
         public static void Error(
             string message,
             [CallerMemberName] string method = "",
             [CallerFilePath] string filePath = "",
             [CallerLineNumber] int lineNumber = 0)
-        { _target?.StartMethod(method, filePath, lineNumber); }
+        {
+            Output(message, method, filePath, lineNumber, LogLevel.Error);
+        }
+
         public static void Exception(
             string message,
             Exception ex,
             [CallerMemberName] string method = "",
             [CallerFilePath] string filePath = "",
             [CallerLineNumber] int lineNumber = 0)
-        { _target?.StartMethod(method, filePath, lineNumber); }
-    }
+        {
+            Output(message + ", Exception: " + ex.ToString(), method, filePath, lineNumber, LogLevel.Error);
+        }
 
-    public interface ILoggerServiceInner
-    {
-        void StartMethod(
-            [CallerMemberName] string method = "",
-            [CallerFilePath] string filePath = "",
-            [CallerLineNumber] int lineNumber = 0);
-        void EndMethod(
-            [CallerMemberName] string method = "",
-            [CallerFilePath] string filePath = "",
-            [CallerLineNumber] int lineNumber = 0);
-        void Verbose(
-            string message,
-            [CallerMemberName] string method = "",
-            [CallerFilePath] string filePath = "",
-            [CallerLineNumber] int lineNumber = 0);
-        void Debug(
-            string message,
-            [CallerMemberName] string method = "",
-            [CallerFilePath] string filePath = "",
-            [CallerLineNumber] int lineNumber = 0);
-        void Info(
-            string message,
-            [CallerMemberName] string method = "",
-            [CallerFilePath] string filePath = "",
-            [CallerLineNumber] int lineNumber = 0);
-        void Warning(
-            string message,
-            [CallerMemberName] string method = "",
-            [CallerFilePath] string filePath = "",
-            [CallerLineNumber] int lineNumber = 0);
-        void Error(
-            string message,
-            [CallerMemberName] string method = "",
-            [CallerFilePath] string filePath = "",
-            [CallerLineNumber] int lineNumber = 0);
-        void Exception(
-            string message,
-            Exception ex,
-            [CallerMemberName] string method = "",
-            [CallerFilePath] string filePath = "",
-            [CallerLineNumber] int lineNumber = 0);
+
+        private static DateTime JstNow()
+        {
+            return TimeZoneInfo.ConvertTime(DateTime.Now, JstTimeZoneInfo());
+        }
+        private static TimeZoneInfo JstTimeZoneInfo()
+        {
+            // iOS/Android/Unix
+            try
+            {
+                return TimeZoneInfo.FindSystemTimeZoneById("Asia/Tokyo");
+            }
+            catch (TimeZoneNotFoundException)
+            {
+                // Not iOS/Android/Unix
+            }
+
+            // Windows
+            try
+            {
+                return TimeZoneInfo.FindSystemTimeZoneById("Tokyo Standard Time");
+            }
+            catch (TimeZoneNotFoundException)
+            {
+                // Not Windows
+            }
+
+            // Emergency fallback
+            return TimeZoneInfo.CreateCustomTimeZone("JST", new TimeSpan(9, 0, 0), "(GMT+09:00) JST", "JST");
+        }
+
+        private static void Output(string message, string method, string filePath, int lineNumber, LogLevel logLevel)
+        {
+            var now = JstNow().ToString("yyyy/MM/dd HH:mm:ss");
+            var level = logLevel.ToString();
+            var line = $"\"{now}\",\"{level}\",\"{message}\",\"{method}\",\"{filePath}\",\"{lineNumber}\",\"Android\",\"\",\"\",\"\",\"\",\"\"";
+            System.Diagnostics.Trace.WriteLine(line);
+            return;
+        }
     }
 }

--- a/Covid19Radar/Xamarin.ExposureNotification/Mock/ExposureNotificationClientMock.android.cs
+++ b/Covid19Radar/Xamarin.ExposureNotification/Mock/ExposureNotificationClientMock.android.cs
@@ -14,46 +14,53 @@ namespace Xamarin.ExposureNotification
     {
         public Task<IList<ExposureInformation>> GetExposureInformationAsync(string token)
         {
-            Xamarin.ExposureNotifications.LoggerService.StartMethod();
+            Xamarin.ExposureNotifications.LogEx.StartMethod();
             var items = new List<ExposureInformation>();
+            Xamarin.ExposureNotifications.LogEx.EndMethod();
             return new Task<IList<ExposureInformation>>(
                 () => { return items; });
         }
 
         public Task<ExposureSummary> GetExposureSummaryAsync(string token)
         {
-            Xamarin.ExposureNotifications.LoggerService.StartMethod();
+            Xamarin.ExposureNotifications.LogEx.StartMethod();
             var item = new ExposureSummary.ExposureSummaryBuilder().Build();
+            Xamarin.ExposureNotifications.LogEx.EndMethod();
             return new Task<ExposureSummary>(
                 () => item);
         }
         public Task<IList<TemporaryExposureKey>> GetTemporaryExposureKeyHistoryAsync()
         {
-            Xamarin.ExposureNotifications.LoggerService.StartMethod();
+            Xamarin.ExposureNotifications.LogEx.StartMethod();
             var items = new List<TemporaryExposureKey>();
+            Xamarin.ExposureNotifications.LogEx.EndMethod();
             return new Task<IList<TemporaryExposureKey>>(
                 () => items);
         }
 
         public Task StartAsync()
         {
-            Xamarin.ExposureNotifications.LoggerService.StartMethod();
+            Xamarin.ExposureNotifications.LogEx.StartMethod();
+            Xamarin.ExposureNotifications.LogEx.EndMethod();
             return new Task(() => { });
         }
         public Task StopAsync()
         {
-            Xamarin.ExposureNotifications.LoggerService.StartMethod();
+            Xamarin.ExposureNotifications.LogEx.StartMethod();
+            Xamarin.ExposureNotifications.LogEx.EndMethod();
             return new Task(() => { });
         }
         public Task<bool> IsEnabledAsync()
         {
-            Xamarin.ExposureNotifications.LoggerService.StartMethod();
+            Xamarin.ExposureNotifications.LogEx.StartMethod();
+            Xamarin.ExposureNotifications.LogEx.EndMethod();
             return new Task<bool>(() => true);
         }
 
         public Task ProvideDiagnosisKeysAsync(List<Java.IO.File> files, ExposureConfiguration config, string guid )
         {
-            Xamarin.ExposureNotifications.LoggerService.StartMethod();
+            Xamarin.ExposureNotifications.LogEx.StartMethod();
+            Xamarin.ExposureNotifications.LogEx.EndMethod();
             return new Task<bool>(() => true);
         }
     }

--- a/Covid19Radar/Xamarin.ExposureNotification/Mock/ExposureNotificationClientMock.android.cs
+++ b/Covid19Radar/Xamarin.ExposureNotification/Mock/ExposureNotificationClientMock.android.cs
@@ -1,0 +1,60 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+using System.Threading.Tasks;
+using Android.Gms.Common.Api.Internal;
+using Android.Gms.Common.Apis;
+using Android.Gms.Nearby.ExposureNotification;
+using Java.Interop;
+using Java.IO;
+
+namespace Xamarin.ExposureNotification
+{
+    class ExposureNotificationClientMock  
+    {
+        public Task<IList<ExposureInformation>> GetExposureInformationAsync(string token)
+        {
+            Xamarin.ExposureNotifications.LoggerService.StartMethod();
+            var items = new List<ExposureInformation>();
+            return new Task<IList<ExposureInformation>>(
+                () => { return items; });
+        }
+
+        public Task<ExposureSummary> GetExposureSummaryAsync(string token)
+        {
+            Xamarin.ExposureNotifications.LoggerService.StartMethod();
+            var item = new ExposureSummary.ExposureSummaryBuilder().Build();
+            return new Task<ExposureSummary>(
+                () => item);
+        }
+        public Task<IList<TemporaryExposureKey>> GetTemporaryExposureKeyHistoryAsync()
+        {
+            Xamarin.ExposureNotifications.LoggerService.StartMethod();
+            var items = new List<TemporaryExposureKey>();
+            return new Task<IList<TemporaryExposureKey>>(
+                () => items);
+        }
+
+        public Task StartAsync()
+        {
+            Xamarin.ExposureNotifications.LoggerService.StartMethod();
+            return new Task(() => { });
+        }
+        public Task StopAsync()
+        {
+            Xamarin.ExposureNotifications.LoggerService.StartMethod();
+            return new Task(() => { });
+        }
+        public Task<bool> IsEnabledAsync()
+        {
+            Xamarin.ExposureNotifications.LoggerService.StartMethod();
+            return new Task<bool>(() => true);
+        }
+
+        public Task ProvideDiagnosisKeysAsync(List<Java.IO.File> files, ExposureConfiguration config, string guid )
+        {
+            Xamarin.ExposureNotifications.LoggerService.StartMethod();
+            return new Task<bool>(() => true);
+        }
+    }
+}

--- a/Covid19Radar/Xamarin.ExposureNotification/Xamarin.ExposureNotification.csproj
+++ b/Covid19Radar/Xamarin.ExposureNotification/Xamarin.ExposureNotification.csproj
@@ -27,7 +27,7 @@
 	</PropertyGroup>
 
 	<PropertyGroup Condition="'$(Configuration)|$(TargetFramework)|$(Platform)'=='Debug_BackTask|netstandard2.0|AnyCPU'">
-	  <DefineConstants>DEBUG;TRACE;TEST_BACKTASK</DefineConstants>
+	  <DefineConstants>TRACE;DEBUG;TEST_BACKTASK</DefineConstants>
 	</PropertyGroup>
 
 	<ItemGroup>


### PR DESCRIPTION
ログ出力先を System.Diagnostics.Trace に統一する。
Xamarin EN 内も Trace に統一して、ILoggerService も元の共通プロジェクトへ戻す。